### PR TITLE
Fjerne versjonering av endeunkter

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/mock/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/mock/SwaggerConfig.kt
@@ -21,7 +21,7 @@ class SwaggerConfig : WebMvcConfigurer {
         return Docket(DocumentationType.SWAGGER_2)
                 .select()
                 .apis(RequestHandlerSelectors.any())
-                .paths(PathSelectors.regex(".*/api/v1/.*"))
+                .paths(PathSelectors.regex(".*/api/.*"))
                 .build()
     }
 

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/HendelseController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/HendelseController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class HendelseController(
         private val hendelseService: HendelseService,
         private val abacService: AbacService

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/KommuneController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/KommuneController.kt
@@ -17,7 +17,7 @@ import java.util.*
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class KommuneController(
         private val kommuneService: KommuneService,
         private val abacService: AbacService

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/NavKontorinfoController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/NavKontorinfoController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn")
+@RequestMapping("/api")
 class NavKontorinfoController(
         private val norgClient: NorgClient
 ) {

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/NoekkelinfoController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/NoekkelinfoController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @ProtectedWithClaims(issuer = "veileder")
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class NoekkelinfoController(
         private val noekkelinfoService: NoekkelinfoService,
         private val abacService: AbacService

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/OppgaveController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class OppgaveController(
         private val oppgaveService: OppgaveService,
         private val abacService: AbacService

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/PersonInfoController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/PersonInfoController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class PersonInfoController(
         private val personinfoService: PersoninfoService,
         private val abacService: AbacService

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/SaksStatusController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/SaksStatusController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class SaksStatusController(
         private val saksStatusService: SaksStatusService,
         private val abacService: AbacService

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/SoknadsStatusController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/SoknadsStatusController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class SoknadsStatusController(
         private val soknadsStatusService: SoknadsStatusService,
         private val abacService: AbacService

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/SoknadsoversiktController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/SoknadsoversiktController.kt
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class SoknadsoversiktController(
         private val fiksClient: FiksClient,
         private val eventService: EventService,

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/UtbetalingerController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/UtbetalingerController.kt
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class UtbetalingerController(
         private val utbetalingerService: UtbetalingerService,
         private val fiksClient: FiksClient,

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/VedleggController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/VedleggController.kt
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(issuer = "veileder")
 @RestController
-@RequestMapping("/api/v1/innsyn", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"], consumes = ["application/json;charset=UTF-8"])
 class VedleggController(
         private val vedleggService: VedleggService,
         private val abacService: AbacService


### PR DESCRIPTION
Fjerne versjonering av endeunkter, da vi har full kontroll på clienten vår.

Fjerner også /innsyn som sikkert henger igjen fra innsyn-api.
Fikser det også på frontend