### PR TITLE
fjerner `hentKommuneStatus`-endepunkt og unødvendig mapping til enum

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/KommuneController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/KommuneController.kt
@@ -23,14 +23,6 @@ class KommuneController(
         private val abacService: AbacService
 ) {
 
-    @PostMapping("/{fiksDigisosId}/kommune")
-    fun hentKommuneStatus(@PathVariable fiksDigisosId: String, @RequestHeader(value = AUTHORIZATION) token: String, @RequestBody ident: Ident): ResponseEntity<String> {
-        abacService.harTilgang(ident.fnr, token)
-
-        val kommuneStatus = kommuneService.getStatus(fiksDigisosId)
-        return ResponseEntity.ok(kommuneStatus.toString())
-    }
-
     @PostMapping("/kommuner/{kommunenummer}")
     fun hentKommuneInfo(@PathVariable kommunenummer: String, @RequestHeader(value = AUTHORIZATION) token: String, @RequestBody ident: Ident): ResponseEntity<KommuneResponse> {
         abacService.harTilgang(ident.fnr, token)

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/service/kommune/KommuneService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/service/kommune/KommuneService.kt
@@ -1,55 +1,15 @@
 package no.nav.sbl.sosialhjelpmodiaapi.service.kommune
 
-import no.nav.sbl.sosialhjelpmodiaapi.client.fiks.FiksClient
-import no.nav.sbl.sosialhjelpmodiaapi.common.FiksException
 import no.nav.sbl.sosialhjelpmodiaapi.logger
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.HAR_KONFIGURASJON_MEN_SKAL_SENDE_VIA_SVARUT
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.IKKE_STOTTET_CASE
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.MANGLER_KONFIGURASJON
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.SKAL_SENDE_SOKNADER_OG_ETTERSENDELSER_VIA_FDA
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_IKKE_MULIG
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SKAL_VISE_FEILSIDE
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SOM_VANLIG
 import no.nav.sosialhjelp.api.fiks.KommuneInfo
 import no.nav.sosialhjelp.client.kommuneinfo.KommuneInfoClient
 import org.springframework.stereotype.Component
 
 @Component
 class KommuneService(
-        private val fiksClient: FiksClient,
         private val kommuneInfoClient: KommuneInfoClient
 ) {
 
-    fun getStatus(fiksDigisosId: String): KommuneStatus {
-        val digisosSak = fiksClient.hentDigisosSak(fiksDigisosId)
-
-        val kommunenummer: String = digisosSak.kommunenummer
-        if (kommunenummer.isEmpty()) {
-            log.warn("Forsøkte å hente kommuneStatus, men DigisosSak.kommunenummer er tom")
-            throw RuntimeException("KommuneStatus kan ikke hentes uten kommunenummer")
-        }
-
-        val kommuneInfo: KommuneInfo
-        try {
-            kommuneInfo = kommuneInfoClient.get(kommunenummer)
-        } catch (e: FiksException) {
-            return MANGLER_KONFIGURASJON
-        }
-
-        return when {
-            !kommuneInfo.kanMottaSoknader && !kommuneInfo.kanOppdatereStatus && !kommuneInfo.harMidlertidigDeaktivertMottak && !kommuneInfo.harMidlertidigDeaktivertOppdateringer -> HAR_KONFIGURASJON_MEN_SKAL_SENDE_VIA_SVARUT
-            kommuneInfo.kanMottaSoknader && !kommuneInfo.kanOppdatereStatus && !kommuneInfo.harMidlertidigDeaktivertMottak && !kommuneInfo.harMidlertidigDeaktivertOppdateringer -> SKAL_SENDE_SOKNADER_OG_ETTERSENDELSER_VIA_FDA
-            kommuneInfo.kanMottaSoknader && kommuneInfo.kanOppdatereStatus && !kommuneInfo.harMidlertidigDeaktivertMottak && !kommuneInfo.harMidlertidigDeaktivertOppdateringer -> SKAL_SENDE_SOKNADER_OG_ETTERSENDELSER_VIA_FDA
-            kommuneInfo.kanMottaSoknader && kommuneInfo.kanOppdatereStatus && kommuneInfo.harMidlertidigDeaktivertMottak && !kommuneInfo.harMidlertidigDeaktivertOppdateringer -> SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SOM_VANLIG
-            kommuneInfo.kanMottaSoknader && !kommuneInfo.kanOppdatereStatus && kommuneInfo.harMidlertidigDeaktivertMottak && !kommuneInfo.harMidlertidigDeaktivertOppdateringer -> SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_IKKE_MULIG
-            kommuneInfo.kanMottaSoknader && kommuneInfo.kanOppdatereStatus && kommuneInfo.harMidlertidigDeaktivertMottak && kommuneInfo.harMidlertidigDeaktivertOppdateringer -> SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SKAL_VISE_FEILSIDE
-
-            else -> {
-                log.warn("Forsøkte å hente kommunestatus, men caset er ikke dekket: $kommuneInfo")
-                return IKKE_STOTTET_CASE
-            }
-        }
-    }
 
     fun get(kommunenummer: String): KommuneInfo {
         return kommuneInfoClient.get(kommunenummer)
@@ -62,14 +22,4 @@ class KommuneService(
     companion object {
         private val log by logger()
     }
-}
-
-enum class KommuneStatus {
-    HAR_KONFIGURASJON_MEN_SKAL_SENDE_VIA_SVARUT,
-    MANGLER_KONFIGURASJON,
-    SKAL_SENDE_SOKNADER_OG_ETTERSENDELSER_VIA_FDA,
-    SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SOM_VANLIG,
-    SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_IKKE_MULIG,
-    SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SKAL_VISE_FEILSIDE,
-    IKKE_STOTTET_CASE
 }

--- a/src/test/kotlin/no/nav/sbl/sosialhjelpmodiaapi/service/kommune/KommuneServiceTest.kt
+++ b/src/test/kotlin/no/nav/sbl/sosialhjelpmodiaapi/service/kommune/KommuneServiceTest.kt
@@ -3,26 +3,15 @@ package no.nav.sbl.sosialhjelpmodiaapi.service.kommune
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.sbl.sosialhjelpmodiaapi.client.fiks.FiksClient
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.HAR_KONFIGURASJON_MEN_SKAL_SENDE_VIA_SVARUT
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.SKAL_SENDE_SOKNADER_OG_ETTERSENDELSER_VIA_FDA
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_IKKE_MULIG
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SKAL_VISE_FEILSIDE
-import no.nav.sbl.sosialhjelpmodiaapi.service.kommune.KommuneStatus.SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SOM_VANLIG
 import no.nav.sosialhjelp.api.fiks.DigisosSak
-import no.nav.sosialhjelp.api.fiks.KommuneInfo
 import no.nav.sosialhjelp.client.kommuneinfo.KommuneInfoClient
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 
 internal class KommuneServiceTest {
 
-    private val fiksClient: FiksClient = mockk()
     private val kommuneInfoClient: KommuneInfoClient = mockk()
 
-    private val service = KommuneService(fiksClient, kommuneInfoClient)
+    private val service = KommuneService(kommuneInfoClient)
 
     private val mockDigisosSak: DigisosSak = mockk()
     private val kommuneNr = "1234"
@@ -31,66 +20,7 @@ internal class KommuneServiceTest {
     internal fun setUp() {
         clearAllMocks()
 
-        every { fiksClient.hentDigisosSak(any()) } returns mockDigisosSak
         every { mockDigisosSak.kommunenummer } returns kommuneNr
     }
 
-    @Test
-    fun `Kommune har konfigurasjon men skal sende via svarut`() {
-        every { kommuneInfoClient.get(any()) } returns KommuneInfo(kommuneNr, false, false, false, false, null, true, null)
-
-        val status = service.getStatus("123")
-
-        assertThat(status).isEqualTo(HAR_KONFIGURASJON_MEN_SKAL_SENDE_VIA_SVARUT)
-    }
-
-    @Test
-    fun `Kommune skal sende soknader og ettersendelser via FIKS API`() {
-        every { kommuneInfoClient.get(any()) } returns KommuneInfo(kommuneNr, true, false, false, false, null, true, null)
-
-        val status1 = service.getStatus("123")
-
-        assertThat(status1).isEqualTo(SKAL_SENDE_SOKNADER_OG_ETTERSENDELSER_VIA_FDA)
-
-        every { kommuneInfoClient.get(any()) } returns KommuneInfo(kommuneNr, true, true, false, false, null, true, null)
-
-        val status2 = service.getStatus("123")
-
-        assertThat(status2).isEqualTo(SKAL_SENDE_SOKNADER_OG_ETTERSENDELSER_VIA_FDA)
-    }
-
-    @Test
-    fun `Kommune skal vise midlertidig feilside og innsyn som vanlig`() {
-        every { kommuneInfoClient.get(any()) } returns KommuneInfo(kommuneNr, true, true, true, false, null, true, null)
-
-        val status = service.getStatus("123")
-
-        assertThat(status).isEqualTo(SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SOM_VANLIG)
-    }
-
-    @Test
-    fun `Kommune skal vise midlertidig feilside og innsyn er ikke mulig`() {
-        every { kommuneInfoClient.get(any()) } returns KommuneInfo(kommuneNr, true, false, true, false, null, true, null)
-
-        val status = service.getStatus("123")
-
-        assertThat(status).isEqualTo(SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_IKKE_MULIG)
-    }
-
-    @Test
-    fun `Kommune skal vise midlertidig feilside og innsyn skal vise feilside`() {
-        every { kommuneInfoClient.get(any()) } returns KommuneInfo(kommuneNr, true, true, true, true, null, true, null)
-
-        val status = service.getStatus("123")
-
-        assertThat(status).isEqualTo(SKAL_VISE_MIDLERTIDIG_FEILSIDE_FOR_SOKNAD_OG_ETTERSENDELSER_INNSYN_SKAL_VISE_FEILSIDE)
-    }
-
-    @Test
-    fun `Ingen originalSoknad - skal kaste feil`() {
-        every { mockDigisosSak.kommunenummer } returns ""
-
-        assertThatExceptionOfType(RuntimeException::class.java).isThrownBy { service.getStatus("123") }
-                .withMessage("KommuneStatus kan ikke hentes uten kommunenummer")
-    }
 }


### PR DESCRIPTION
https://jira.adeo.no/browse/DIGISOS-1812 
Hvis frontend ikke trenge endepunktet kan det slettes