### PR TITLE
Test/labs bug

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/config/RestConfig.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/config/RestConfig.kt
@@ -14,10 +14,18 @@ import java.nio.charset.StandardCharsets
 class RestConfig {
 
     @Bean
-    fun restTemplate(builder: RestTemplateBuilder): RestTemplate =
-            builder
-//                    .messageConverters(MappingJackson2HttpMessageConverter(objectMapper))
-                    .build()
+    fun restTemplate(builder: RestTemplateBuilder): RestTemplate {
+        val restTemplate = builder
+                .build()
+
+        restTemplate.messageConverters
+                .removeIf { httpMessageConverter -> httpMessageConverter.javaClass == MappingJackson2HttpMessageConverter::class.java }
+
+        restTemplate.messageConverters
+                .add(MappingJackson2HttpMessageConverter(objectMapper))
+
+        return restTemplate
+    }
 
     @Bean
     @Profile("!(mock | local)")


### PR DESCRIPTION
 `.additionalMessageConverters` --> feil på labs/lokalt. JsonHendelse ble ikke deserialisert til subklasser
`.messageConverters` --> feil i dev-fss ved håndtering av response fra idporten.

--> maunelt fjerner og legger til MappingJackson2HttpConverter som er konfigurert med objectMapper fra filformat