### PR TITLE
Inkludere x-client-trace-id i CORS Allow-Headers.

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/config/CORSFilter.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/config/CORSFilter.kt
@@ -28,7 +28,7 @@ class CORSFilter : Filter {
 
         if (!isRunningInProd() || ALLOWED_ORIGINS.contains(origin)) {
             httpResponse.setHeader("Access-Control-Allow-Origin", origin)
-            httpResponse.setHeader("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, X-XSRF-TOKEN, Authorization, Nav-Call-Id")
+            httpResponse.setHeader("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, X-XSRF-TOKEN, Authorization, Nav-Call-Id, x-client-trace-id")
             httpResponse.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
             httpResponse.setHeader("Access-Control-Allow-Credentials", "true")
         }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/mock/responses/DigisosSoker.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/mock/responses/DigisosSoker.kt
@@ -233,7 +233,13 @@ val digisosSoker = JsonDigisosSoker()
                                 .withTom(toDateString(DateTime.now().minusMonths(2).minusDays(5).withDayOfMonth(1).minusDays(1)))
                                 .withAnnenMottaker(false)
                                 .withMottaker("Ola Nordman")
-                                .withKontonummer(null)
-                                .withUtbetalingsmetode("pengekort")
+                                .withKontonummer("0102 0304 050607")
+                                .withUtbetalingsmetode("pengekort"),
+
+                        JsonUtbetaling()
+                                .withType(JsonHendelse.Type.UTBETALING)
+                                .withHendelsestidspunkt(toStringWithTimezone(DateTime.now().plusMonths(1).minusDays(3)))
+                                .withUtbetalingsreferanse("Betaling 5")
+                                .withUtbetalingsdato(toDateString(DateTime.now().minusMonths(1).withDayOfMonth(10)))
                 )
         )!!


### PR DESCRIPTION
NB: Denne burde fjernes igjen når testing med trace er ferdig.

Legger også til to nye mocker av utbetaling. En med kontonummer og en minimal (men med utbetalingsdato)