### PR TITLE
Returnerer msgraph token som cookie. Pga det kreves fra modiacontextholder

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/LoginController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/rest/LoginController.kt
@@ -1,0 +1,36 @@
+package no.nav.sbl.sosialhjelpmodiaapi.rest
+
+import no.nav.sbl.sosialhjelpmodiaapi.utils.MiljoUtils
+import no.nav.sbl.sosialhjelpmodiaapi.utils.TokenUtils
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
+
+@ProtectedWithClaims(issuer = "azuread")
+@RestController
+@RequestMapping("/api", produces = ["application/json;charset=UTF-8"])
+class LoginController(
+        private val tokenUtils: TokenUtils,
+        private val miljoUtils: MiljoUtils
+) {
+
+    @GetMapping("/login")
+    fun login(response: HttpServletResponse): ResponseEntity<String> {
+
+        val msgraphAccessToken = tokenUtils.hentTokenMedGraphScope()
+        val msgraphCookie = Cookie(MSGRAPH_COOKIE_NAME, msgraphAccessToken)
+        msgraphCookie.isHttpOnly = true
+        msgraphCookie.secure = !miljoUtils.isProfileMockOrLocal()
+        msgraphCookie.path = "/"
+        response.addCookie(msgraphCookie)
+        return ResponseEntity.ok("login ok")
+    }
+
+    companion object {
+        const val MSGRAPH_COOKIE_NAME = "isso-accesstoken" // NB: Navnet "isso-accesstoken" kreves av modiacontextholder.
+    }
+}

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/utils/MiljoUtils.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/utils/MiljoUtils.kt
@@ -10,16 +10,17 @@ class MiljoUtils {
     private var activeProfile: String = PROD_FSS // default verdi er prod-fss
 
     fun isProfileMockOrLocal(): Boolean {
-        return activeProfile == MOCK || activeProfile == LOCAL
+        return activeProfile.contains(MOCK) || activeProfile.contains(MOCK_ALT) || activeProfile.contains(LOCAL)
     }
 
     fun isRunningInProd(): Boolean {
-        return activeProfile == PROD_FSS
+        return activeProfile.contains(PROD_FSS)
     }
 
     companion object {
         private const val LOCAL = "local"
         private const val MOCK = "mock"
+        private const val MOCK_ALT = "mock-alt"
         private const val PROD_FSS = "prod-fss"
     }
 }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/utils/TokenUtils.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/utils/TokenUtils.kt
@@ -7,8 +7,8 @@ import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 interface TokenUtils {
-
     fun hentNavIdentForInnloggetBruker(): String
+    fun hentTokenMedGraphScope(): String
 }
 
 @Profile("!(mock | mock-alt | local)")
@@ -19,7 +19,7 @@ class TokenUtilsImpl(
         private val msGraphClient: MsGraphClient
 ) : TokenUtils {
 
-    private fun hentTokenMedGraphScope(): String {
+    override fun hentTokenMedGraphScope(): String {
         val clientProperties = clientConfigurationProperties.registration["onbehalfof"]
         val response = oAuth2AccessTokenService.getAccessToken(clientProperties)
         return response.accessToken
@@ -36,5 +36,9 @@ class MockTokenUtils : TokenUtils {
 
     override fun hentNavIdentForInnloggetBruker(): String {
         return "Z123456"
+    }
+
+    override fun hentTokenMedGraphScope(): String {
+        return "msgraph-token"
     }
 }


### PR DESCRIPTION
* Nytt endepunkt /login, som sjekker at bruker er logget inn og returnerer en cookie med msgraph-cookie. Denne må dessverre til fordi modiacontexthandler forventer en slik cookie. Det kan hende det er mer rett å bruke idtoken enn access-token...
* Lar cookien ha secure:false når man kjører lokalt eller i mock (secure krever https)
* Fikser MiljoUtil slik at den forstår at man er i et miljø selv om profiles kanskje inneholder flere (feks mock, log-console skal gi true på mock). Legger til mock-alt