### PR TITLE
Tar i bruk Unleash for featureToggle "fiksCacheEnabled"

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/client/fiks/FiksClientImpl.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/client/fiks/FiksClientImpl.kt
@@ -1,13 +1,14 @@
 package no.nav.sbl.sosialhjelpmodiaapi.client.fiks
 
+import no.finn.unleash.Unleash
 import no.nav.sbl.sosialhjelpmodiaapi.client.fiks.FiksPaths.PATH_ALLE_DIGISOSSAKER
 import no.nav.sbl.sosialhjelpmodiaapi.client.fiks.FiksPaths.PATH_DIGISOSSAK
 import no.nav.sbl.sosialhjelpmodiaapi.client.fiks.FiksPaths.PATH_DOKUMENT
+import no.nav.sbl.sosialhjelpmodiaapi.client.unleash.FIKS_CACHE_ENABLED
 import no.nav.sbl.sosialhjelpmodiaapi.config.ClientProperties
 import no.nav.sbl.sosialhjelpmodiaapi.feilmeldingUtenFnr
 import no.nav.sbl.sosialhjelpmodiaapi.logger
 import no.nav.sbl.sosialhjelpmodiaapi.logging.AuditService
-import no.nav.sbl.sosialhjelpmodiaapi.redis.CacheProperties
 import no.nav.sbl.sosialhjelpmodiaapi.redis.RedisService
 import no.nav.sbl.sosialhjelpmodiaapi.service.idporten.IdPortenService
 import no.nav.sbl.sosialhjelpmodiaapi.toFiksErrorMessage
@@ -39,7 +40,7 @@ class FiksClientImpl(
         private val auditService: AuditService,
         private val redisService: RedisService,
         private val tokenUtils: TokenUtils,
-        private val cacheProperties: CacheProperties
+        private val unleash: Unleash,
 ) : FiksClient {
 
     private val baseUrl = clientProperties.fiksDigisosEndpointUrl
@@ -57,7 +58,7 @@ class FiksClientImpl(
     }
 
     private fun skalBrukeCache(): Boolean {
-        return cacheProperties.fiksCacheEnabled
+        return unleash.isEnabled(FIKS_CACHE_ENABLED, false)
     }
 
     private fun hentDigisosSakFraCache(digisosId: String): DigisosSak? {

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/client/unleash/FeatureToggleNames.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/client/unleash/FeatureToggleNames.kt
@@ -1,0 +1,3 @@
+package no.nav.sbl.sosialhjelpmodiaapi.client.unleash
+
+const val FIKS_CACHE_ENABLED = "sosialhjelp.modia.fiks-cache-enabled"

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/redis/CacheProperties.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpmodiaapi/redis/CacheProperties.kt
@@ -13,8 +13,6 @@ class CacheProperties {
 
     var timeToLiveSeconds: Long by Delegates.notNull()
 
-    var fiksCacheEnabled: Boolean by Delegates.notNull()
-
     fun startInMemoryRedisIfMocked() {
         if (redisMocked) {
             startRedisMocked()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,7 +8,6 @@ modia:
   cache:
     redis_mocked: true
     time_to_live_seconds: 5
-    fiks_cache_enabled: false
 
 no.nav.security.jwt:
   issuer.azuread:

--- a/src/main/resources/application-mock-alt.yml
+++ b/src/main/resources/application-mock-alt.yml
@@ -7,7 +7,6 @@ modia:
   cache:
     redis_mocked: true
     time_to_live_seconds: 2
-    fiks_cache_enabled: false
 
 no.nav.security.jwt:
   issuer.azuread:

--- a/src/main/resources/application-mock.yml
+++ b/src/main/resources/application-mock.yml
@@ -8,7 +8,6 @@ modia:
   cache:
     redis_mocked: true
     time_to_live_seconds: 2
-    fiks_cache_enabled: false
 
 no.nav.security.jwt:
   issuer.azuread:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,6 @@ modia:
   cache:
     redis_mocked: false
     time_to_live_seconds: ${CACHE_TIME_TO_LIVE_SECONDS}
-    fiks_cache_enabled: false
 
 server:
   port: 8383

--- a/src/test/kotlin/no/nav/sbl/sosialhjelpmodiaapi/client/fiks/FiksClientTest.kt
+++ b/src/test/kotlin/no/nav/sbl/sosialhjelpmodiaapi/client/fiks/FiksClientTest.kt
@@ -7,10 +7,11 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import no.finn.unleash.Unleash
 import no.nav.sbl.soknadsosialhjelp.digisos.soker.JsonDigisosSoker
+import no.nav.sbl.sosialhjelpmodiaapi.client.unleash.FIKS_CACHE_ENABLED
 import no.nav.sbl.sosialhjelpmodiaapi.config.ClientProperties
 import no.nav.sbl.sosialhjelpmodiaapi.logging.AuditService
-import no.nav.sbl.sosialhjelpmodiaapi.redis.CacheProperties
 import no.nav.sbl.sosialhjelpmodiaapi.redis.RedisService
 import no.nav.sbl.sosialhjelpmodiaapi.responses.ok_digisossak_response_string
 import no.nav.sbl.sosialhjelpmodiaapi.responses.ok_minimal_jsondigisossoker_response_string
@@ -38,9 +39,9 @@ internal class FiksClientTest {
     private val auditService: AuditService = mockk()
     private val redisService: RedisService = mockk()
     private val tokenUtils: TokenUtils = mockk()
-    private val cacheProperties: CacheProperties = mockk(relaxed = true)
+    private val unleash: Unleash = mockk()
 
-    private val fiksClient = FiksClientImpl(clientProperties, restTemplate, idPortenService, auditService, redisService, tokenUtils, cacheProperties)
+    private val fiksClient = FiksClientImpl(clientProperties, restTemplate, idPortenService, auditService, redisService, tokenUtils, unleash)
 
     private val id = "123"
 
@@ -55,7 +56,7 @@ internal class FiksClientTest {
         every { redisService.set(any(), any()) } just Runs
 
         every { tokenUtils.hentNavIdentForInnloggetBruker() } returns "11111111111"
-        every { cacheProperties.fiksCacheEnabled } returns true
+        every { unleash.isEnabled(FIKS_CACHE_ENABLED, false) } returns true
     }
 
     @Test


### PR DESCRIPTION
FiksClient skal cache responser til redis. (Burde være disabled frem til session-id er på plass)
https://unleash.nais.io/#/features/strategies/sosialhjelp.modia.fiks-cache-enabled