### PR TITLE
abac-sosialhjelp er oppdatert til å gå mot PDL fremfor TPS. 

### DIFF
--- a/nais/dev/dev-fss.json
+++ b/nais/dev/dev-fss.json
@@ -10,7 +10,7 @@
     "/serviceuser/srvsosialhjelp-mod": "/serviceuser/data/dev/srvsosialhjelp-mod"
   },
   "env": {
-    "ABAC_PDP_ENDPOINT_URL": "https://abac-sosialhjelp.nais.preprod.local/application/authorize",
+    "ABAC_PDP_ENDPOINT_URL": "https://abac-sosialhjelp.dev.intern.nav.no/application/authorize",
     "FIKS_DIGISOS_ENDPOINT_URL": "https://api.fiks.test.ks.no",
     "ID_PORTEN_TOKEN_URL": "https://oidc-ver2.difi.no/idporten-oidc-provider/token",
     "ID_PORTEN_CONFIG_URL": "https://oidc-ver2.difi.no/idporten-oidc-provider/.well-known/openid-configuration",

--- a/nais/prod/prod-fss.json
+++ b/nais/prod/prod-fss.json
@@ -9,7 +9,7 @@
     "/serviceuser/srvsosialhjelp-mod": "/serviceuser/data/prod/srvsosialhjelp-mod"
   },
   "env": {
-    "ABAC_PDP_ENDPOINT_URL": "https://abac-sosialhjelp.nais.adeo.no/application/authorize",
+    "ABAC_PDP_ENDPOINT_URL": "https://abac-sosialhjelp.intern.nav.no/application/authorize",
     "FIKS_DIGISOS_ENDPOINT_URL": "https://api.fiks.ks.no",
     "ID_PORTEN_TOKEN_URL": "https://oidc.difi.no/idporten-oidc-provider/token",
     "ID_PORTEN_CONFIG_URL": "https://oidc.difi.no/idporten-oidc-provider/.well-known/openid-configuration",


### PR DESCRIPTION
https://confluence.adeo.no/pages/viewpage.action?pageId=402567407