### PR TITLE
Bump jsonsmart and snyk-fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,7 +135,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:${Versions.junitJupiter}")
     testImplementation("io.mockk:mockk:${Versions.mockk}")
     testImplementation("no.nav.security:token-validation-spring-test:${Versions.tokenValidation}")
-//    testImplementation("org.jetbrains.kotlin:kotlin-test:${Versions.kotlin}")
 
 //    Spesifikke versjoner oppgradert etter ønske fra snyk
     constraints {

--- a/src/test/kotlin/no/nav/sosialhjelp/modia/client/sts/STSClientTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/modia/client/sts/STSClientTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
-import kotlin.test.assertNotNull
 
 internal class STSClientTest {
 
@@ -42,7 +41,7 @@ internal class STSClientTest {
 
         val accessToken = stsClient.token()
 
-        assertNotNull(accessToken)
+        assertThat(accessToken).isNotNull
         assertThat(accessToken).isEqualTo(token.access_token)
     }
 
@@ -63,7 +62,7 @@ internal class STSClientTest {
 
         val firstToken = stsClient.token()
 
-        assertNotNull(firstToken)
+        assertThat(firstToken).isNotNull
         assertThat(firstToken).isEqualTo(token.access_token)
         verify(exactly = 1) { restTemplate.exchange(any<String>(), HttpMethod.POST, any(), STSToken::class.java) }
 
@@ -90,12 +89,12 @@ internal class STSClientTest {
 
         val firstToken = stsClient.token()
 
-        assertNotNull(firstToken)
+        assertThat(firstToken).isNotNull
         verify(exactly = 1) { restTemplate.exchange(any<String>(), HttpMethod.POST, any(), STSToken::class.java) }
 
         val secondToken = stsClient.token()
 
-        assertNotNull(secondToken)
+        assertThat(secondToken).isNotNull
         verify(exactly = 2) { restTemplate.exchange(any<String>(), HttpMethod.POST, any(), STSToken::class.java) }
     }
 }

--- a/src/test/kotlin/no/nav/sosialhjelp/modia/rest/SoknadsoversiktControllerTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/modia/rest/SoknadsoversiktControllerTest.kt
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import java.time.LocalDateTime
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 internal class SoknadsoversiktControllerTest {
 
@@ -99,12 +97,12 @@ internal class SoknadsoversiktControllerTest {
             val first = saker[0]
             assertThat(first.soknadTittel).isEqualTo("Søknad om økonomisk sosialhjelp")
             assertThat(first.kilde).isEqualTo(KILDE_INNSYN_API)
-            assertNotNull(first.sendt)
+            assertThat(first.sendt).isNotNull
 
             val second = saker[1]
             assertThat(second.soknadTittel).isEqualTo("Søknad om økonomisk sosialhjelp")
             assertThat(second.kilde).isEqualTo(KILDE_INNSYN_API)
-            assertNull(second.sendt)
+            assertThat(second.sendt).isNull()
         }
     }
 

--- a/src/test/kotlin/no/nav/sosialhjelp/modia/service/utbetalinger/UtbetalingerServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/modia/service/utbetalinger/UtbetalingerServiceTest.kt
@@ -25,7 +25,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import kotlin.test.assertTrue
 
 internal class UtbetalingerServiceTest {
     private val fiksClient: FiksClient = mockk()
@@ -192,7 +191,7 @@ internal class UtbetalingerServiceTest {
 
         assertThat(response).isNotNull
         assertThat(response).hasSize(1)
-        assertTrue(response[0].harVilkar)
+        assertThat(response[0].harVilkar).isTrue
     }
 
     @Disabled("disabled frem til det blir bekreftet om dokumentasjonkrav skal være med i response")


### PR DESCRIPTION
kun denne gjenstår:
```
Issues with no direct upgrade or patch:
  ✗ Improper Certificate Validation [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-1042268] in io.netty:netty-handler@4.1.63.Final
    introduced by io.netty:netty-handler@4.1.63.Final
  No upgrade or patch available
```
Mistenker at hvis vi går over til webclient (fra resttemplate) og bumper sosialhjelp-common vil få vekk denne.