### PR TITLE
fix path/query params

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/modia/client/fiks/FiksClientImpl.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/modia/client/fiks/FiksClientImpl.kt
@@ -31,7 +31,6 @@ import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
-import org.springframework.web.util.UriComponentsBuilder
 import java.util.UUID
 
 @Profile("!mock")
@@ -81,7 +80,7 @@ class FiksClientImpl(
 
         val digisosSak: DigisosSak? = withRetry {
             fiksWebClient.get()
-                .uri(withSporingsId(PATH_DIGISOSSAK), digisosId, sporingsId)
+                .uri(PATH_DIGISOSSAK.plus(sporingsIdQuery), digisosId, sporingsId)
                 .headers { it.addAll(fiksHeaders(clientProperties, BEARER + virksomhetsToken.token)) }
                 .retrieve()
                 .bodyToMono<DigisosSak>()
@@ -124,7 +123,7 @@ class FiksClientImpl(
 
         val dokument: Any? = withRetry {
             fiksWebClient.get()
-                .uri(withSporingsId(PATH_DOKUMENT), digisosId, dokumentlagerId, sporingsId)
+                .uri(PATH_DOKUMENT.plus(sporingsIdQuery), digisosId, dokumentlagerId, sporingsId)
                 .headers { it.addAll(fiksHeaders(clientProperties, BEARER + virksomhetsToken.token)) }
                 .retrieve()
                 .bodyToMono(requestedClass)
@@ -151,7 +150,7 @@ class FiksClientImpl(
 
         val digisosSaker: List<DigisosSak>? = withRetry {
             fiksWebClient.post()
-                .uri(withSporingsId(PATH_ALLE_DIGISOSSAKER), sporingsId)
+                .uri(PATH_ALLE_DIGISOSSAKER.plus(sporingsIdQuery), sporingsId)
                 .headers { it.addAll(fiksHeaders(clientProperties, BEARER + virksomhetsToken.token)) }
                 .body(BodyInserters.fromValue(Fnr(fnr)))
                 .retrieve()
@@ -191,14 +190,13 @@ class FiksClientImpl(
     companion object {
         private val log by logger()
 
-        private fun withSporingsId(path: String): String {
-            return UriComponentsBuilder.fromPath(path)
-                .queryParam("SPORINGSID", "{$SPORINGSID}")
-                .toUriString()
-        }
+        private val sporingsIdQuery: String
+            get() = "?$SPORINGSID={$SPORINGSID}"
 
         //        Query param navn
         private const val SPORINGSID = "sporingsId"
+        private const val DIGISOSID = "digisosId"
+        private const val DOKUMENTLAGERID = "dokumentlagerId"
 
         private const val retryAttempts: Int = 5
         private const val initialDelayMillis: Long = 100


### PR DESCRIPTION
slik at metrikker ikke populeres med `digisosId`, `dokumentlagerId` og `sporingsId`