### PR TITLE
korrigerer NORG_OPPSLAG_URL, 

### DIFF
--- a/nais/dev/dev-fss.json
+++ b/nais/dev/dev-fss.json
@@ -14,7 +14,7 @@
     "VEILEDER_GRUPPE_ID": "7357bc5c-8389-435d-8311-46452d356a83",
     "FIKS_DIGISOS_ENDPOINT_URL": "https://api.fiks.test.ks.no",
     "NORG_ENDPOINT_URL": "https://norg2.dev.adeo.no/norg2/api/v1",
-    "NORG_OPPSLAG_URL": "https://norg2-frontend.dev.adeo.no/#/startsok?enhetNr=",
+    "NORG_OPPSLAG_URL": "https://norg2-frontend.dev.intern.nav.no/#/startsok?enhetNr=",
     "PDL_ENDPOINT_URL": "https://pdl-api.nais.preprod.local/graphql",
     "PDL_SCOPE": "api://dev-fss.pdl.pdl-api/.default",
     "SKJERMEDE_PERSONER_ENDPOINT_URL": "https://skjermede-personer-pip.dev.intern.nav.no",

--- a/nais/dev/dev.json
+++ b/nais/dev/dev.json
@@ -14,7 +14,7 @@
     "VEILEDER_GRUPPE_ID": "55f10d2b-f3ac-4d85-b989-655145ab5f30",
     "FIKS_DIGISOS_ENDPOINT_URL": "https://api.fiks.test.ks.no",
     "NORG_ENDPOINT_URL": "https://norg2.dev-fss-pub.nais.io/norg2/api/v1",
-    "NORG_OPPSLAG_URL": "https://norg2-frontend.dev.adeo.no/#/startsok?enhetNr=",
+    "NORG_OPPSLAG_URL": "https://norg2-frontend.dev.intern.nav.no/#/startsok?enhetNr=",
     "PDL_ENDPOINT_URL": "https://pdl-api.dev-fss-pub.nais.io/graphql",
     "PDL_SCOPE": "api://dev-fss.pdl.pdl-api/.default",
     "SKJERMEDE_PERSONER_ENDPOINT_URL": "https://skjermede-personer-pip.dev.intern.nav.no",

--- a/nais/dev/mock.json
+++ b/nais/dev/mock.json
@@ -19,7 +19,7 @@
     "VEILEDER_GRUPPE_ID": "0000-MOCK-sosialhjelp-modia-veileder",
     "FIKS_DIGISOS_ENDPOINT_URL": "http://sosialhjelp-mock-alt-api-mock/sosialhjelp/mock-alt-api/fiks",
     "NORG_ENDPOINT_URL": "http://sosialhjelp-mock-alt-api-mock/sosialhjelp/mock-alt-api/norg_endpoint_url",
-    "NORG_OPPSLAG_URL": "https://norg2-frontend.dev.adeo.no/#/startsok?enhetNr=",
+    "NORG_OPPSLAG_URL": "https://digisos.ekstern.dev.nav.no/sosialhjelp/modia",
     "PDL_ENDPOINT_URL": "http://sosialhjelp-mock-alt-api-mock/sosialhjelp/mock-alt-api/pdl_endpoint_url",
     "PDL_SCOPE": "dummyScope",
     "SKJERMEDE_PERSONER_ENDPOINT_URL": "http://sosialhjelp-mock-alt-api-mock/sosialhjelp/mock-alt-api/skjermede-personer",

--- a/nais/prod/prod-fss.json
+++ b/nais/prod/prod-fss.json
@@ -14,7 +14,7 @@
     "VEILEDER_GRUPPE_ID": "82efbcf9-7a99-4c60-9242-79c439ca3cdc",
     "FIKS_DIGISOS_ENDPOINT_URL": "https://api.fiks.ks.no",
     "NORG_ENDPOINT_URL": "https://norg2.nais.adeo.no/norg2/api/v1",
-    "NORG_OPPSLAG_URL": "https://norg2-frontend.nais.adeo.no/#/startsok?enhetNr=",
+    "NORG_OPPSLAG_URL": "https://norg2-frontend.intern.nav.no/#/startsok?enhetNr=",
     "PDL_ENDPOINT_URL": "https://pdl-api.nais.adeo.no/graphql",
     "PDL_SCOPE": "api://prod-fss.pdl.pdl-api/.default",
     "SKJERMEDE_PERSONER_ENDPOINT_URL": "https://skjermede-personer-pip.intern.nav.no",


### PR DESCRIPTION
det viser seg at vi lenker til ingresser som ble fjernet i desember ⚠️ 