### PR TITLE
mottar vi tilleggsinformasjon (og enhetsnummer) for papirsøknader?

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/modia/digisossak/event/EventService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/modia/digisossak/event/EventService.kt
@@ -49,6 +49,10 @@ class EventService(
             model.navKontorHistorikk.add(NavKontorInformasjon(SendingType.SENDT, unixToLocalDateTime(timestampSendt), enhetsnummer, navenhetsnavn))
         }
 
+        if (timestampSendt == null) { // papirsoknad
+            log.info("Papirsoknad ${digisosSak.fiksDigisosId} - Tilleggsinformasjon.enhetsnummer: ${digisosSak.tilleggsinformasjon?.enhetsnummer}")
+        }
+
         jsonDigisosSoker?.hendelser
             ?.sortedWith(hendelseComparator)
             ?.forEach { model.applyHendelse(it) }


### PR DESCRIPTION
Litt ekstra logging som kan fjernes igjen snart