### PR TITLE
overskriver maskinporten url for dev-fss.

### DIFF
--- a/nais/dev/dev-fss.yaml
+++ b/nais/dev/dev-fss.yaml
@@ -89,3 +89,5 @@ spec:
       value: "true"
     - name: MODIA_BASEURL
       value: "https://sosialhjelp-modia.dev.intern.nav.no/sosialhjelp/modia"
+    - name: MASKINPORTEN_WELL_KNOWN_URL
+      value: "https://ver2.maskinporten.no/.well-known/oauth-authorization-server"


### PR DESCRIPTION
ettersom KS ikke støtter test.maskinporten.no som ny issuer enda.