### PR TITLE
Ikke slett prod-images

### DIFF
--- a/.github/workflows/delete_images.yml
+++ b/.github/workflows/delete_images.yml
@@ -15,3 +15,4 @@ jobs:
           package-name: 'sosialhjelp-modia-api/sosialhjelp-modia-api'
           package-type: 'container'
           min-versions-to-keep: 50
+          ignore-versions: 'prod-'


### PR DESCRIPTION
For å forhindre feilen vi har hatt et par ganger med at prod går ned når image er sletta og VM/pod restartes.